### PR TITLE
Add info about defconfig adaptation and kernel-info.mk file and the system image guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Contents
   * [Droidian device page](https://devices.droidian.org)
 * Porting guide
   * [Kernel compilation](./kernel-compilation.md)
-  * [System image creation](./image-creation.md), This guide should only be used for legacy devices (devices released without a vendor partition).
+  * [System image creation](./image-creation.md), This guide should only be used for legacy devices (devices released without a vendor partition). Any device released with Android 9 or later can use the generic system image provided in Droidian
   * [Tips to aid debugging](./debugging-tips.md)
   * [Rootfs creation](./rootfs-creation.md)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Droidian porting guide
-===========================
+======================
 
 Droidian is a GNU/Linux distribution based on top of [Mobian](https://mobian-project.org),
 a Debian-based distribution for mobile devices.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ Contents
   * [Kernel compilation](./kernel-compilation.md)
   * [Image creation](./image-creation.md)
   * [Tips to aid debugging](./debugging-tips.md)
+
+Getting community help
+----------------------
+
+### Search the Droidian group
+
+The [Droidian telegram group](https://t.me/DroidianLinux/) (also bridged to [Matrix](https://matrix.to/#/%23droidian:matrix.org)) is a great resource.
+It's quite possible that your issue has been already discussed and resolved.
+
+Please use the search function rather than ask straight away. Discussing the same things at length
+is boring especially when it has been already done in the past.
+
+If you can't find an answer for your issue, try to be the more detailed possible (include a pastebin of your
+logs). If someone is available it will try to help you.
+
+Note that no one owes you an answer, avoid pinging people repeatedly. Avoid posting screenshots of
+text messages, use a pastebin service instead.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 Droidian porting guide
 ======================
 
@@ -11,6 +12,10 @@ This is accomplished by using well-known technologies such as [libhybris](https:
 If your device is launched with Android 9 or above it is possible to port Droidian to it.
 If it already has a halium-compliant kernel of halium-9.0 and above chances are that Droidian will work without much modification.
 
+The "System image creation" guide should only be used for legacy devices (devices released without a vendor partition) which have an Android 9 port (device tree, vendor tree and kernel source).
+Legacy devices without an Android 9 port cannot be ported to Droidian. So it's either Android 9 or bust!
+Any device released with Android 8.1 or later can use the generic system image provided in Droidian and skip this section.
+
 Contents
 --------
 
@@ -18,7 +23,7 @@ Contents
   * [Droidian device page](https://devices.droidian.org)
 * Porting guide
   * [Kernel compilation](./kernel-compilation.md)
-  * [System image creation](./image-creation.md), This guide should only be used for legacy devices (devices released without a vendor partition). Any device released with Android 9 or later can use the generic system image provided in Droidian
+  * [System image creation](./image-creation.md), skip this section if your device is treble/has a vendor partition (released with Android 8.1 or later).
   * [Tips to aid debugging](./debugging-tips.md)
   * [Rootfs creation](./rootfs-creation.md)
 
@@ -38,3 +43,4 @@ logs). If someone is available it will try to help you.
 
 Note that no one owes you an answer, avoid pinging people repeatedly. Avoid posting screenshots of
 text messages, use a pastebin service instead.
+

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Contents
   * [Droidian device page](https://devices.droidian.org)
 * Porting guide
   * [Kernel compilation](./kernel-compilation.md)
-  * [Image creation](./image-creation.md)
+  * [System image creation](./image-creation.md), This guide should only be used for legacy devices (devices released without a vendor partition).
   * [Tips to aid debugging](./debugging-tips.md)
+  * [Adaptation creation](./adaptation-creation.md)
+  * [Rootfs creation](./rootfs-creation.md)
 
 Getting community help
 ----------------------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-
 Droidian porting guide
 ======================
 
-Droidian is a GNU/Linux distribution based on top of [Mobian](https://mobian-project.org),
-a Debian-based distribution for mobile devices.
+Droidian is a GNU/Linux distribution based on top of [Mobian](https://mobian-project.org), a Debian-based distribution for mobile devices.
 
 The goal of Droidian is to be able to run Mobian on Android phones.
 
@@ -13,7 +11,9 @@ If your device is launched with Android 9 or above it is possible to port Droidi
 If it already has a halium-compliant kernel of halium-9.0 and above chances are that Droidian will work without much modification.
 
 The "System image creation" guide should only be used for legacy devices (devices released without a vendor partition) which have an Android 9 port (device tree, vendor tree and kernel source).
+
 Legacy devices without an Android 9 port cannot be ported to Droidian. So it's either Android 9 or bust!
+
 Any device released with Android 8.1 or later can use the generic system image provided in Droidian and skip this section.
 
 Contents

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Contents
   * [Kernel compilation](./kernel-compilation.md)
   * [System image creation](./image-creation.md), This guide should only be used for legacy devices (devices released without a vendor partition).
   * [Tips to aid debugging](./debugging-tips.md)
-  * [Adaptation creation](./adaptation-creation.md)
   * [Rootfs creation](./rootfs-creation.md)
 
 Getting community help

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ It's quite possible that your issue has been already discussed and resolved.
 Please use the search function rather than ask straight away. Discussing the same things at length
 is boring especially when it has been already done in the past.
 
-If you can't find an answer for your issue, try to be the more detailed possible (include a pastebin of your
-logs). If someone is available it will try to help you.
+If you can't find an answer for your issue, try to be as detailed as possible (include a pastebin of your logs). 
+When someone is available, they will try to help you out.
 
 Note that no one owes you an answer, avoid pinging people repeatedly. Avoid posting screenshots of
 text messages, use a pastebin service instead.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ a Debian-based distribution for mobile devices.
 
 The goal of Droidian is to be able to run Mobian on Android phones.
 
-This is accomplished by using well-known technologies such as [libhybris](https://github.com/libhybris/libhybris)
-and [halium](https://halium.org).
+This is accomplished by using well-known technologies such as [libhybris](https://github.com/libhybris/libhybris) and [halium](https://halium.org).
 
-If your device supports `halium-9.0`, chances are that it can run Droidian easily.
+If your device is launched with Android 9 or above it is possible to port Droidian to it.
+If it already has a halium-compliant kernel of halium-9.0 and above chances are that Droidian will work without much modification.
 
 Contents
 --------
 
 * Currently known-to-work and supported devices
+  * [Droidian device page](https://devices.droidian.org)
 * Porting guide
   * [Kernel compilation](./kernel-compilation.md)
-  * Image creation
+  * [Image creation](./image-creation.md)
   * [Tips to aid debugging](./debugging-tips.md)

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -268,8 +268,7 @@ respawned by the android init automatically.
 
 ### Make the Phosh service wait some seconds before start-up
 
-Sometimes Phosh might attempt its startup even when the Android composer service is not
-ready (even if it signals so itself).
+Sometimes Phosh might attempt its startup even when the Android composer service is not ready (even if it signals so itself).
 
 This is a bug, and you can workaround that by making the phosh service (which starts the compositor) wait some seconds:
 
@@ -285,6 +284,30 @@ ExecStartPre=/usr/bin/sleep 5
 ```
 
 Save and reboot.
+
+### Vendor is not mounted
+
+It is possible that the vendor partition doesn't get mounted by init and as a result the Halium contianer cannot start much of the services.
+
+First off check if the vendor image is mounted
+
+	(device)# ls /vendor
+
+If it's empty then it is not mounted by init. Try mounting it manually by finding the partition in `/dev/disk/by-partlabel` and `/dev/block/bootdevice/by-name`.
+
+If it is not there then you'll need to search `/dev` for your vendor partition.
+
+Then to test it out, in `/var/lib/lxc/android/pre-start.sh` add the following under the `# Halium 9` section
+
+```
+mkdir -p /var/lib/lxc/android/rootfs/vendor
+mount /dev/mmcblk0pYOURVENDOR /vendor
+mount --bind /vendor /var/lib/lxc/android/vendor
+```
+
+And reboot
+
+Make sure to come back to this issue later to find a proper solution.
 
 Tips for when the system is up with Phosh
 -----------------------------------------

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -76,20 +76,6 @@ harder to debug.
 	(recovery)$ export PATH=/usr/bin:/usr/sbin
 	(recovery)$ systemctl mask systemd-journald
 
-### Check pstore for clues
-
-If you have pstore enabled, you might find clues in `/sys/fs/pstore` from your
-recovery.
-
-If you don't have it enabled, you should add these options to your kernel configuration:
-
-```
-CONFIG_PSTORE=y
-CONFIG_PSTORE_CONSOLE=y
-CONFIG_PSTORE_RAM=y
-CONFIG_PSTORE_RAM_ANNOTATION_APPEND=y
-```
-
 ### (generic rootfs only) Check systemd journal for clues
 
 If you haven't masked journald, and have devtools (or a nightly image) installed, you

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -171,6 +171,17 @@ If you configured using DHCP, you should check among your DHCP server leases.
 
 The default password is `1234`.
 
+### ssh saying system is still booting
+
+To make ssh ignore systemd complaining, [this](https://github.com/droidian-mt6765/adaptation-droidian-garden/blob/main/debian/adaptation-garden-configs.ssh-fix.service) service file can added in recovery
+
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+
+And add this service file.
+
 ### Continue trying other stuff
 
 If you are still unable to get a shell, you might want to continue reading
@@ -258,3 +269,77 @@ ExecStartPre=/usr/bin/sleep 5
 ```
 
 Save and reboot.
+
+### Screen brightness
+
+On some Qualcomm devices, screen brightness is always set to 0 on boot. to work around this issue brightness can be set to maximum on each boot
+
+	(device)$ echo 2047 > /sys/class/leds/lcd-backlight/brightness
+
+It can also be set as a service to start at boot like [this service file](https://github.com/droidian-lavender/adaptation-droidian-lavender/blob/main/debian/adaptation-lavender-configs.brightness.service).
+
+On Mediatek devices, power button will stop working after being used once.
+
+[This hack](https://github.com/droidian-mt6765/garden_power_button_helper) or a hack close to it can be used for now.
+
+It should be compiled on the device itself or it can be cross compiled from a computer.
+
+### Phosh scaling
+
+Phosh might have the wrong scaling set. phoc.ini should be created to adjust it
+
+	(device)# mkdir -p /etc/phosh/
+	(device)# nano phoc.ini
+
+and put [this](https://github.com/droidian-lavender/adaptation-droidian-lavender/blob/main/etc/phosh/phoc.ini)
+
+the value for `output:HWCOMPOSER-1` should be adjusted.
+
+### vendor overlay
+
+To overlay a file over vendor, the droid-vendor-overlay can be used
+
+	(device)# mkdir -p /usr/lib/droid-vendor-overlay
+
+and the your files can be added here. take [this](https://github.com/droidian-mt6765/adaptation-droidian-garden/tree/main/usr/lib/droid-vendor-overlay) as a reference.
+
+It should be noted that the directory structure matters.
+
+### system overlay
+
+To overlay a file over system, the droid-system-overlay can be used
+
+	(device)# mkdir -p /usr/lib/droid-system-overlay
+
+and the your files can be added here. take [this](https://github.com/droidian-devices/adaptation-fxtec-pro1x/tree/bookworm/sparse/usr/lib/droid-system-overlay) as a reference.
+
+It should be noted that the directory structure matters.
+
+### Bluetooth crashing
+
+Bluetooth might crash because of missing MAC Address. To make the bluetooth service ignore it this hack can be used
+
+	(device)# mkdir -p /var/lib/bluetooth/
+	(device)# touch /var/lib/bluetooth/board-address
+
+For a proper solution, a `droid-get-bt-address.sh` script which fetches the correct address should be created.
+
+An example of this solution can be found at [here](https://github.com/droidian-sargo/adaptation-droidian-sargo/blob/bookworm/usr/bin/droid/droid-get-bt-address.sh) for Qualcomm's
+and [here](https://github.com/droidian-mt6765/adaptation-droidian-garden/blob/main/usr/bin/droid/droid-get-bt-address.sh) for Mediatek's.
+
+### Audio adjusting not working
+
+on Mediatek devices, pulseaudio requires a custom configuration file which can be found [here](https://github.com/droidian-mt6765/adaptation-droidian-garden/blob/main/etc/pulse/arm_droid_card_custom.pa).
+
+### Custom hostname
+
+To set a custom hostname on boot, a preferred hostname file can be created
+
+	(device)# mkdir -p /var/lib/droidian/
+	(device)# nano preferred_hostname
+
+And put your device model or codename without any spaces
+
+### Kernel modules
+
+`systemd-modules-load` doesn't load the modules on Mediatek. [This](https://github.com/droidian-mt6765/adaptation-droidian-garden/blob/main/debian/adaptation-garden-configs.modules.service) service to some similar implementation can be included to load all the correct modules and get Wi-Fi working.

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -318,21 +318,3 @@ ExecStartPre=/usr/bin/sleep 5
 ```
 
 Save and reboot.
-
-
-No dice?
---------
-
-### Search the Droidian group
-
-The [Droidian telegram group](https://t.me/DroidianLinux/) (also bridged to [Matrix](https://matrix.to/#/%23droidian:matrix.org)) is a great resource.  
-It's quite possible that your issue has been already discussed and resolved.
-
-Please use the search function rather than ask straight away. Discussing the same things at length
-is boring especially when it has been already done in the past.
-
-If you can't find an answer for your issue, try to be the more detailed possible (include a pastebin of your
-logs). If someone is available it will try to help you.
-
-Note that no one owes you an answer, avoid pinging people repeatedly. Avoid posting screenshots of
-text messages, use a pastebin service instead.

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -1,7 +1,7 @@
 Debugging tips
 ==============
 
-When porting a new device, you might (will) encounter some issues.  
+When porting a new device, you might (will) encounter some issues.
 It's unlikely that everything will work fine at first boot, so strap in, read
 this document twice and enjoy your ride.
 
@@ -23,19 +23,14 @@ Some recoveries might fail in resizing the Droidian rootfs. This will in turn
 break the boot process (and eventual feature bundles installation) due to the
 lack of available free space.
 
-You can open a shell from your recovery (either via `adb shell` or with the built-in
-terminal) and check:
+You can open a shell from your recovery (either via `adb shell` or with the built-in terminal) and check:
 
-```
-ls -lth /data/rootfs.img
-```
+	(recovery)$ ls -lth /data/rootfs.img
 
 if the image size is not 8GB, you can attempt resizing it manually:
 
-```
-e2fsck -fy /data/rootfs.img
-resize2fs -f /data/rootfs.img 8G
-```
+	(recovery)$ e2fsck -fy /data/rootfs.img
+	(recovery)$ resize2fs -f /data/rootfs.img 8G
 
 ### (generic rootfs only) Install devtools
 
@@ -75,14 +70,11 @@ Some devices have trouble with systemd-journald. You might try masking it via re
 Note that masking journald will disable log collection, so other issues will be
 harder to debug.
 
-```
-# From a recovery shell
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-chroot /tmp/mpoint /bin/bash
-export PATH=/usr/bin:/usr/sbin
-systemctl mask systemd-journald
-```
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+	(recovery)$ systemctl mask systemd-journald
 
 ### Check pstore for clues
 
@@ -103,14 +95,11 @@ CONFIG_PSTORE_RAM_ANNOTATION_APPEND=y
 If you haven't masked journald, and have devtools (or a nightly image) installed, you
 can check the systemd journal:
 
-```
-# From a recovery shell
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-chroot /tmp/mpoint /bin/bash
-export PATH=/usr/bin:/usr/sbin
-journalctl --no-pager
-```
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+	(recovery)$ journalctl --no-pager
 
 Stuck at the glowing Droidian logo, and RNDIS is not working
 ------------------------------------------------------------
@@ -121,16 +110,6 @@ and "Check systemd journal for clues" parts. They'll help here as well.**
 If you have devtools installed (or have flashed a nightly image) but still don't
 have working RNDIS, these tips might help you:
 
-### Check your kernel configuration
-
-Re-check your kernel configuration using [mer-kernel-check](https://github.com/mer-hybris/mer-kernel-check).
-
-Ensure kernel namespaces features are enabled (like `CONFIG_NAMESPACES`, `CONFIG_UTS_NS`, `CONFIG_IPC_NS`,
-`CONFIG_PID_NS`, `CONFIG_NET_NS`...).
-
-You might also check this diffconfig snippet for the official Sony Xperia 5 adaptation:
-https://github.com/droidian-devices/android_kernel_sony_kumano/blob/droidian/55.2.A.4.xxx/droidian/halium.config
-
 ### (generic rootfs only) Mask resolved and timesyncd
 
 Some kernels have trouble with the kernel namespaces systemd creates to run some
@@ -138,15 +117,12 @@ daemons, like timesyncd and resolved. This might make the boot process hang.
 
 You might try masking those two services via a recovery shell:
 
-```
-# From a recovery shell
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-chroot /tmp/mpoint /bin/bash
-export PATH=/usr/bin:/usr/sbin
-systemctl mask systemd-resolved
-systemctl mask systemd-timesyncd
-```
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+	(recovery)$ systemctl mask systemd-resolved
+	(recovery)$ systemctl mask systemd-timesyncd
 
 **If this worked, re-check your kernel configuration. See the section above.**
 
@@ -157,20 +133,15 @@ the RNDIS connection.
 
 You can disable the Halium container startup with the following:
 
-```
-# From a recovery shell
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-chroot /tmp/mpoint /bin/bash
-export PATH=/usr/bin:/usr/sbin
-nano /etc/systemd/system/lxc@android.service
-```
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+	(recovery)$ nano /etc/systemd/system/lxc@android.service
 
 Comment the ExecStartPre and ExecStart lines, add
 
-```
-ExecStart=/bin/true
-```
+`ExecStart=/bin/true`
 
 save, sync and reboot
 
@@ -179,14 +150,11 @@ save, sync and reboot
 You might try pre-configuring your WLAN device and attempt getting in via WLAN
 rather than RNDIS:
 
-```
-# From a recovery shell
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-chroot /tmp/mpoint /bin/bash
-export PATH=/usr/bin:/usr/sbin
-nano /etc/network/interfaces
-```
+	(recovery)$ mkdir /tmp/mpoint
+	(recovery)$ mount /data/rootfs.img /tmp/mpoint
+	(recovery)$ chroot /tmp/mpoint /bin/bash
+	(recovery)$ export PATH=/usr/bin:/usr/sbin
+	(recovery)$ nano /etc/network/interfaces
 
 and put the following there:
 
@@ -233,19 +201,15 @@ Stuck at the Droidian logo, but I have a shell
 
 You can start a root shell with
 
-```
-sudo -i
-```
+	(device)$ sudo -i
 
 ### Umount schedtune
 
 Schedtune must be disabled for Droidian to work, but some device kernels complain
 about that. So the workaround is to umount schedtune at boot:
 
-```
-mkdir -p /etc/systemd/system/android-mount.service.d
-nano /etc/systemd/system/android-mount.service.d/10-schedtune.conf
-```
+	(device)# mkdir -p /etc/systemd/system/android-mount.service.d
+	(device)# nano /etc/systemd/system/android-mount.service.d/10-schedtune.conf
 
 add this there:
 
@@ -260,9 +224,7 @@ save and reboot
 
 You can use
 
-```
-lxc-ls --fancy
-```
+	(device)# lxc-ls --fancy
 
 to check if the Halium container is running
 
@@ -270,29 +232,23 @@ to check if the Halium container is running
 
 If the Halium container is not running, you might try launching it manually:
 
-```
-lxc-start -n android --logfile=/tmp/lxclog --logpriority=DEBUG
-```
+	(device)# lxc-start -n android --logfile=/tmp/lxclog --logpriority=DEBUG
 
 then check `/tmp/lxclog`.
-
 
 ### Re-generate udev rules
 
 If the container is running, but you still haven't booted up to UI, you might try
-regenerating the udev rules (snippet from the [ubports halium-9 porting notes](https://github.com/ubports/porting-notes/wiki/Halium-9#generating-udev-rules))
+regenerating the udev rules (snippet from the [UBports halium-9 porting notes](https://github.com/ubports/porting-notes/wiki/Halium-9#generating-udev-rules))
 
-```
-DEVICE=pro1 # replace with your device codename
-cat /var/lib/lxc/android/rootfs/ueventd*.rc /vendor/ueventd*.rc | grep ^/dev | sed -e 's/^\/dev\///' | awk '{printf "ACTION==\"add\", KERNEL==\"%s\", OWNER=\"%s\", GROUP=\"%s\", MODE=\"%s\"\n",$1,$3,$4,$2}' | sed -e 's/\r//' >/etc/udev/rules.d/70-$DEVICE.rules
-```
+	(device)# DEVICE=codename # replace with your device codename
+	(device)# cat /var/lib/lxc/android/rootfs/ueventd*.rc /vendor/ueventd*.rc | grep ^/dev | sed -e 's/^\/dev\///' | awk '{printf "ACTION==\"add\", KERNEL==\"%s\", OWNER=\"%s\", GROUP=\"%s\", MODE=\"%s\"\n",$1,$3,$4,$2}' | sed -e 's/\r//' >/etc/udev/rules.d/70-$DEVICE.rules
 
 Then reboot.
 
 ### Check if test_hwcomposer works
 
-Trying the `test_hwcomposer` command might be an useful test to check if the Android
-composer works.
+Trying the `test_hwcomposer` command might be an useful test to check if the Android composer works.
 
 Note that on Halium 10/11 devices you might need to restart the Android composer service after
 using a client like test_hwcomposer or phoc itself. You can kill the `android.service.composer` process, it will be
@@ -304,10 +260,8 @@ Sometimes phosh might attempt its startup even when the android composer service
 ready (even if it signals so itself). This is a bug, and you can workaround that by
 making the phosh service (which starts the compositor) wait some seconds:
 
-```
-mkdir -p /etc/systemd/system/phosh.service.d/
-nano /etc/systemd/system/phosh.service.d/90-wait.conf
-```
+	(device)# mkdir -p /etc/systemd/system/phosh.service.d/
+	(device)# nano /etc/systemd/system/phosh.service.d/90-wait.conf
 
 and put this there:
 

--- a/debugging-tips.md
+++ b/debugging-tips.md
@@ -302,12 +302,22 @@ Then to test it out, in `/var/lib/lxc/android/pre-start.sh` add the following un
 ```
 mkdir -p /var/lib/lxc/android/rootfs/vendor
 mount /dev/mmcblk0pYOURVENDOR /vendor
-mount --bind /vendor /var/lib/lxc/android/vendor
+mount --bind /vendor /var/lib/lxc/android/rootfs/vendor
 ```
 
 And reboot
 
 Make sure to come back to this issue later to find a proper solution.
+
+### Long boot times
+
+If you are encountering long boot times, you can try inspecting kernel logs and check what process was keeping the system from booting up
+
+	(device)# dmesg
+
+To figure out which part of the boot process is causing the issue
+
+	(device)# systemd-analyze
 
 Tips for when the system is up with Phosh
 -----------------------------------------

--- a/image-creation.md
+++ b/image-creation.md
@@ -40,19 +40,19 @@ Before we start, It should be noted that the Android build system will be well o
 
 First create a directory for the Halium/Android build system
 
-`mkdir droidian && cd droidian`
+`(host)$ mkdir droidian && cd droidian`
 
 and initialize the correct manifest file for your Halium version (in this case it will he halium-9.0)
 
-`repo init -u https://github.com/Halium/android -b halium-9.0 --depth=1`
+`(host)$ repo init -u https://github.com/Halium/android -b halium-9.0 --depth=1`
 
 Now you are ready to clone into all the repositories and download the source code for the required repositories. (This will take some time)
 
-`repo sync -c`
+`(host)$ repo sync -c`
 
 If you have a fast connection you can increase the number of workers with -j
 
-`repo sync -c -j 16`
+`(host)$ repo sync -c -j 16`
 
 Writing a manifest file
 ---------------------------
@@ -119,18 +119,18 @@ After completing your manifest file you can use the setup script to set your dev
 
 Make sure to run these commands at the root of your droidian directory
 
-`halium/devices/setup CODENAME`
+`(host)$ halium/devices/setup CODENAME`
 
 replace CODENAME with your codename
 
 Then apply the hybris patches for the build system
 
-`hybris-patches/apply-patches.sh --mb`
+`(host)$ hybris-patches/apply-patches.sh --mb`
 
 Now all we have to do to have a ready to build environment is to set the set up the environment variables
 ```
-source build/envsetup.sh
-breakfast CODENAME
+(host)$ source build/envsetup.sh
+(host)$ breakfast CODENAME
 ```
 
 replace CODENAME with your codename
@@ -206,20 +206,20 @@ Compiling
 
 To build mkbootimg which is used for building the final boot image
 
-`mka mkbootimg`
+`(host)$ mka mkbootimg`
 
 To build the boot image
 
 ```
-export USE_HOST_LEX=yes
-mka halium-boot
+(host)$ export USE_HOST_LEX=yes
+(host)$ mka halium-boot
 ```
 
 And finally to build the system image
 
 ```
-mka e2fsdroid
-mka systemimage
+(host)$ mka e2fsdroid
+(host)$ mka systemimage
 ```
 
 Obtaining images
@@ -237,30 +237,30 @@ rootfs modification
 
 To test this image in Droidian, it should first be converted from a sparse image to a raw image
 
-`simg2img system.img system-raw.img`
+`(host)$ simg2img system.img system-raw.img`
 
 Now it can safely be moved to our Droidian installation.
 
 Assuming device is already booted into Droidian, scp can be used to move the image.
 
-`scp system-raw.img droidian@10.15.19.82:~/`
+`(host)$ scp system-raw.img droidian@10.15.19.82:~/`
 
 Now ssh into your device
 
-`ssh droidian@10.15.19.82`
+`(host)$ ssh droidian@10.15.19.82`
 
 And move the image to `/var/lib/lxc/android/`
 
-`sudo cp system-raw.img /var/lib/lxc/android/android-rootfs.img`
+`(device)$ sudo cp system-raw.img /var/lib/lxc/android/android-rootfs.img`
 
 If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image
 
-`adb push system-raw.img /data/`
+`(host)$ adb push system-raw.img /data/`
 
 Now from recovery shell
 
 ```
-mkdir /tmp/mpoint
-mount /data/rootfs.img /tmp/mpoint
-cp /data/system-raw.img /tmp/mpoint/var/lib/lxc/android/android-rootfs.img
+(recovery)$ mkdir /tmp/mpoint
+(recovery)$ mount /data/rootfs.img /tmp/mpoint
+(recovery)$ cp /data/system-raw.img /tmp/mpoint/var/lib/lxc/android/android-rootfs.img
 ```

--- a/image-creation.md
+++ b/image-creation.md
@@ -1,0 +1,227 @@
+Image creation
+==================
+Devices released before the treble/GSI move require a system image to be built because the default image will not provide the required libraries to the system.
+
+Table of contents
+-----------------
+
+* [Summary](#summary)
+* [Prerequisites](#Prerequisites)
+* [Build environment](#build-environment)
+* [Writing a manifest file](#writing-a-manifest-file)
+* [Initializing the build environment](#initializing-the-build-environment)
+* [Kernel adaptation](#kernel-adaptation)
+* [Device tree modifications](#device-tree-modifications)
+* [Compiling](#compiling)
+* [Obtaining images](#obtaining-images)
+* [rootfs modification](#rootfs-modification)
+
+Summary
+-------
+
+Halium based operating systems use Android drivers to make use of the systems hardware. doing so can make the process of porting a lot faster and smoother.
+
+To do so it uses an Android container running a very trimmed down version of Android in the background. Then uses middleware and various patches to system software to make use of those loaded drivers.
+
+on GSI systems a system image which makes use of the vendor partition for system firmware can be used. but on older devices without a vendor partition (non-Treble), a system image has to be built from scratch.
+
+Currently this method only works on devices with Android 9 (halium-9.0). As an example a device released with Android 7 but with Android 9 ported to the device.
+
+Prerequisites
+-------------
+
+* Device kernel source
+* Device tree source
+* Device vendor tree source (if applicable)
+
+Build-environment
+----------------
+Before we start, It should be noted that the Android build system will be well over 50GB when building and is about 35GB on start without any modifications. So make sure you have enough storage before starting the process.
+
+First create a directory for the Halium/Android build system
+
+`mkdir droidian && cd droidian`
+
+and initialize the correct manifest file for your Halium version (in this case it will he halium-9.0)
+
+`repo init -u https://github.com/Halium/android -b halium-9.0 --depth=1`
+
+Now you are ready to clone into all the repositories and download the source code for the required repositories. (This will take some time)
+
+`repo sync -c`
+
+If you have a fast connection you can increase the number of workers with -j
+
+`repo sync -c -j 16`
+
+Writing a manifest file
+---------------------------
+After downloading all the sources you'll need to write a manifest file for your device.
+A manifest file is a file in which the location to all your sources on the internet and the location of all your sources on your local disk is stored.
+
+Manifest files are stored in halium/devices/manifests and the file name has the format `vendor_device.xml` in which device is the codename of your device
+As an example for Xiaomi Redmi Note 7 it will be `xiaomi_lavender.xml`
+
+Your manifest file should have this and everything else goes in the middle
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+</manifest>
+```
+
+Remotes can be created
+`<remote name="github" fetch="https://github.com/" revision="halium-9.0" />`
+
+This means that each time github is used as the remote repository will be searched for in github.com and the branch will always be halium-9.0 (revision can be removed from remote and can be moved to project entries)
+
+project entries indicate the repository to clone into
+
+`<project path="device/lge/hammerhead" name="droidian-hammerhead/android_kernel_lge_hammerhead" remote="github" />`
+
+This line indicates that the build script should look at the remote github (which is https://github.com/) and clone into the repository `droidian-hammerhead/android_kernel_lge_hammerhead` (https://github.com/droidian-hammerhead/android_kernel_lge_hammerhead) and store it at device/lge/hammerhead from the root of the build system.
+
+Because we have revision="halium-9.0" it will also make sure to clone into the halium-9.0 branch. revision can also be added to the project line instead of the remote if not all repositories have the same branch name.
+
+After adding all the entries for your device (kernel, device, vendor and possibly other entries such as slsi for Samsung devices), you can move on to the next step.
+
+Initializing the build environment
+----------------------------------
+
+After completing your manifest file you can use the setup script to set your device as the target for building.
+
+Make sure to run these commands at the root of your droidian directory
+
+`halium/devices/setup CODENAME`
+
+replace CODENAME with your codename
+
+Then apply the hybris patches for the build system
+
+`hybris-patches/apply-patches.sh --mb`
+
+Now all we have to do to have a ready to build environment is to set the set up the environment variables
+
+`source build/envsetup.sh`
+`breakfast CODENAME`
+
+replace CODENAME with your codename
+
+Device tree modifications
+-------------------------
+
+Most Android devices don't have the console we read from in their bootloader string. This can be added to the device tree like so
+
+`BOARD_KERNEL_CMDLINE += console=tty0`
+
+It should be added to `device/vendor/codename/BoardConfig.mk`
+
+For Halium 9, we need the system image to be built as system-as-root 
+
+`BOARD_BUILD_SYSTEM_ROOT_IMAGE := true`
+
+As this change makes the android root read-only, we may have to ship mount points for some important partitions like firmware, persist with the system image, for this we can use the line
+
+```BOARD_ROOT_EXTRA_FOLDERS := \
+ /firmware \
+ /dsp \
+ /persist
+```
+
+You may need to add more mount points depending on your device. After successful boot do `ls -la /` and add folders corresponding to broken symlinks.
+
+Kernel adaptation
+-----------------
+
+As a bare minimum these options need to be enabled in your defconfig
+
+```
+CONFIG_DEVTMPFS
+CONFIG_VT
+CONFIG_NAMESPACES
+CONFIG_MODULES
+CONFIG_DEVPTS_MULTIPLE_INSTANCES
+CONFIG_USB_CONFIGFS_RNDIS
+```
+
+Usually CONFIG_NAMESPACES enables all the namespace options but if it did not, all these options should be added
+
+```
+CONFIG_SYSVIPC
+CONFIG_PID_NS
+CONFIG_IPC_NS
+CONFIG_UTS_NS
+```
+
+If device fails to set console from our device tree to tty0 this hack can be used
+
+```
+CONFIG_CMDLINE="console=tty0"
+CONFIG_CMDLINE_EXTEND=y
+```
+
+Later on for other components, other options can be enabled after the initial boot is done successfully.
+
+As an example for Bluetooth these options might be required
+
+```
+CONFIG_BT
+CONFIG_BT_HCIVHCI
+```
+
+You can use menuconfig to make sure all the options are enabled with all their dependencies.
+
+If LXC fails to start you can use `lxc-checkconfig` after device first booted to check for other options that might be needed.
+
+Compiling
+---------
+
+To build mkbootimg which is used for building the final boot image
+
+`mka mkbootimg`
+
+To build the boot image
+
+```
+export USE_HOST_LEX=yes
+mka halium-boot
+```
+
+And finally to build the system image
+
+```
+mka e2fsdroid
+mka systemimage
+```
+
+Obtaining images
+----------------
+
+If everything went smoothly without any errors, you should be able to find all the images in `out/target/product/CODENAME` where CODENAME is your codename.
+You should see `system.img` as well as `halium-boot.img`.
+
+halium-boot.img should be flashed to the boot partition of the device.
+
+rootfs modification
+------------------
+
+To test this image in Droidian, it should first be converted from a sparse image to a raw image
+
+`simg2img system.img system-raw.img`
+
+Now it can safely be moved to our Droidian installation.
+
+Assuming device is already booted into Droidian, scp can be used to move the image.
+
+`scp system-raw.img droidian@10.15.19.82:~/`
+
+Now ssh into your device
+
+`ssh droidian@10.15.19.82`
+
+And move the image to `/var/lib/lxc/android/`
+
+`sudo cp system-raw.img /var/lib/lxc/android/android-rootfs.img`
+
+If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image to `MOUNTPOINT/var/lib/lxc/android/android-rootfs.img`

--- a/image-creation.md
+++ b/image-creation.md
@@ -102,9 +102,10 @@ Then apply the hybris patches for the build system
 `hybris-patches/apply-patches.sh --mb`
 
 Now all we have to do to have a ready to build environment is to set the set up the environment variables
-
-`source build/envsetup.sh`
-`breakfast CODENAME`
+```
+source build/envsetup.sh
+breakfast CODENAME
+```
 
 replace CODENAME with your codename
 
@@ -201,7 +202,7 @@ Obtaining images
 If everything went smoothly without any errors, you should be able to find all the images in `out/target/product/CODENAME` where CODENAME is your codename.
 You should see `system.img` as well as `halium-boot.img`.
 
-halium-boot.img should be flashed to the boot partition of the device.
+`halium-boot.img` should be flashed to the boot partition of the device.
 
 rootfs modification
 ------------------
@@ -224,4 +225,6 @@ And move the image to `/var/lib/lxc/android/`
 
 `sudo cp system-raw.img /var/lib/lxc/android/android-rootfs.img`
 
-If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image to `MOUNTPOINT/var/lib/lxc/android/android-rootfs.img`
+If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image to
+
+`MOUNTPOINT/var/lib/lxc/android/android-rootfs.img`

--- a/image-creation.md
+++ b/image-creation.md
@@ -62,29 +62,55 @@ A manifest file is a file in which the location to all your sources on the inter
 Manifest files are stored in halium/devices/manifests and the file name has the format `vendor_device.xml` in which device is the codename of your device
 As an example for Xiaomi Redmi Note 7 it will be `xiaomi_lavender.xml`
 
-Your manifest file should have this and everything else goes in the middle
+Your manifest file should have this as the starter code and everything should be appended
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
+    <remote name="github" fetch="https://github.com/" />
 
+    <remove-project name="halium/halium-boot" />
+    <project path="halium/halium-boot" name="droidian-hammerhead/halium-boot" remote="github" />    
+    
 </manifest>
 ```
 
-Remotes can be created
+### Remotes
+
+Remotes can be created to mark which git instance each project should be cloned from. as an example
+
 `<remote name="github" fetch="https://github.com/" revision="halium-9.0" />`
 
 This means that each time github is used as the remote repository will be searched for in github.com and the branch will always be halium-9.0 (revision can be removed from remote and can be moved to project entries)
 
-project entries indicate the repository to clone into
+The only condition for a remote is the fetch value must be a git instance.
+
+## Project
+
+Project entries indicate the repository to clone into. as an example
 
 `<project path="device/lge/hammerhead" name="droidian-hammerhead/android_kernel_lge_hammerhead" remote="github" />`
 
 This line indicates that the build script should look at the remote github (which is https://github.com/) and clone into the repository `droidian-hammerhead/android_kernel_lge_hammerhead` (https://github.com/droidian-hammerhead/android_kernel_lge_hammerhead) and store it at device/lge/hammerhead from the root of the build system.
 
-Because we have revision="halium-9.0" it will also make sure to clone into the halium-9.0 branch. revision can also be added to the project line instead of the remote if not all repositories have the same branch name.
+Because we have revision="halium-9.0" it will also make sure to clone into the halium-9.0 branch.
+revision can also be added to the project line instead of the remote if not all repositories have the same branch name.
+
+`<project path="device/lge/hammerhead" name="droidian-hammerhead/android_kernel_lge_hammerhead" remote="github" revision="halium-9.0" />`
 
 After adding all the entries for your device (kernel, device, vendor and possibly other entries such as slsi for Samsung devices), you can move on to the next step.
+
+### Remove project
+
+remove-project entires are used to remove a directory or file in the build system. as an example
+
+`<remove-project name="hybris-patches" />`
+
+This line removes hybris-patches directory. It can then be replaced by another project
+
+`<project path="hybris-patches" name="Halium/hybris-patches" revision="halium-9.0-arm32" />`
+
+On this example it is replaced by an arm32 version of hybris patches needed for devices with a 32 bit CPU as the default hybris-patches is arm64.
 
 Initializing the build environment
 ----------------------------------
@@ -204,6 +230,8 @@ You should see `system.img` as well as `halium-boot.img`.
 
 `halium-boot.img` should be flashed to the boot partition of the device.
 
+The kernel image already embeds the generic Halium initramfs.
+
 rootfs modification
 ------------------
 
@@ -225,6 +253,14 @@ And move the image to `/var/lib/lxc/android/`
 
 `sudo cp system-raw.img /var/lib/lxc/android/android-rootfs.img`
 
-If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image to
+If device is not booted up yet, rootfs can be modified from recovery by mounting it (`/data/rootfs.img`) and copying the image
 
-`MOUNTPOINT/var/lib/lxc/android/android-rootfs.img`
+`adb push system-raw.img /data/`
+
+Now from recovery shell
+
+```
+mkdir /tmp/mpoint
+mount /data/rootfs.img /tmp/mpoint
+cp /data/system-raw.img /tmp/mpoint/var/lib/lxc/android/android-rootfs.img
+```

--- a/image-creation.md
+++ b/image-creation.md
@@ -204,7 +204,7 @@ After the system image is tested and confirmed working then you can move on to [
 Packaging up the system image
 -----------------------------
 
-You'll have to package your system image to use later on when building your rootfs in [Rootfs creation](#rootfs-creation)
+You'll have to package your system image to use later on when building your rootfs in [Rootfs creation](./rootfs-creation)
 
 The main note here is that when building your debian package with your system image, it should have `android-system-gsi-28` as a conflicting package.
 

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -1,12 +1,9 @@
-
 Kernel compilation
 ==================
 
-The stock Android kernel is unfortunately not enough to be able to run
-Droidian.
+The stock Android kernel is unfortunately not enough to be able to run Droidian.
 
-The good news is that, on GSI-capable devices, often only kernel changes
-are necessary.
+The good news is that, on GSI-capable devices, often only kernel changes are necessary.
 
 Table of contents
 -----------------
@@ -14,6 +11,8 @@ Table of contents
 * [Summary](#summary)
 * [Prerequisites](#prerequisites)
 * [Package bring-up](#package-bring-up)
+* [Kernel info options](#kernel-info-options)
+* [Kernel adaptation](#kernel-adaptation)
 * [Compiling](#compiling)
 * [Obtaining the boot image](#obtaining-the-boot-image)
 * [Committing changes](#committing-changes)
@@ -21,29 +20,24 @@ Table of contents
 Summary
 -------
 
-Droidian runs on [halium](https://halium.org). If your device is
-supported by halium-9.0, chances are that Droidian would work
-on it.
+Droidian runs on [halium](https://halium.org).
+If your device is launched with Android 9 or above it is possible to port Droidian to it.
+If it already has a halium-compliant kernel of halium-9.0 and above chances are that Droidian will work without much modification.
 
-If your device has shipped with Android 8.1 or 9, it probably is
-GSI (Generic System Image) capable, and such it's possible to use
-an already available, generic Android System Image with Halium patches
-applied.
+If your device has shipped with Android 8.1 or 9, it probably is GSI (Generic System Image) capable, and such it's possible to use an already available, generic Android System Image with Halium patches applied.
+This will reduce the amount of work the porter has to do significantly.
 
-If your device doesn't support GSI, you'll also need to compile a patched
-system image. This is beyond the scope of this document.
+If your device doesn't support GSI, you'll also need to compile a patched system image.
+The documentation for image creation can be found in [this guide](./image-creation.md)
 
-On Halium, the Android kernel is built via the standard Android toolchain.  
-While this makes sense, on GSI-capable devices this can be a waste of time
-since often only kernel changes are required.
+On Halium, the Android kernel is built via the standard Android toolchain.
+While this makes sense, on GSI-capable devices this can be a waste of time since often only kernel changes are required.
 
-Thus, Droidian uses a different approach to compile kernels - the
-upside is that you get packaging for free so that kernels can be upgraded
-over-the-air via APT, if you wish so.
+Thus, Droidian uses a different approach to compile kernels - the upside is that you get packaging for free so that kernels can be upgraded over-the-air via APT, if you wish so.
 
 Note that this guide assumes that you're going to cross-compile an arm64
 Android kernel on an x86_64 (amd64) machine using the Android-supplied
-precompiled toolchain that's available in the Droidian repositories.  
+precompiled toolchain that's available in the Droidian repositories.
 It's trivial to disable cross-compiling and compiling using the standard
 Debian toolchain.
 
@@ -58,7 +52,7 @@ Prerequisites
 * A Halium-compliant kernel defconfig
 * Docker
 
-If you do not have a Halium-compliant kernel yet you can try modifying the defconfig as suggested in [Kernel adaptation](#kernel-adaptation)
+If you do not have a Halium-compliant kernel yet you can try modifying the defconfig as suggested in [Kernel adaptation](#kernel-adaptation) later in the guide.
 
 Package bring-up
 ----------------
@@ -114,54 +108,55 @@ by unpacking an already built `boot.img` using unpackbootimg all the offsets can
 Kernel info options
 -------------------
 
-```KERNEL_BASE_VERSION``` is the kernel version which can be viewed in Makefile at the root of your kernel source.
-as an example
+`KERNEL_BASE_VERSION` is the kernel version which can be viewed in Makefile at the root of your kernel source.
+
+As an example
 
 ```
 VERSION = 4
 PATCHLEVEL = 14
 SUBLEVEL = 221
 ```
+
 will be 4.14.221
 
-```KERNEL_DEFCONFIG``` is the defconfig filename found at arch/YOURARCH/configs
+`KERNEL_DEFCONFIG` is the defconfig filename found at arch/YOURARCH/configs
 
-```KERNEL_IMAGE_WITH_DTB``` determines whether or not to include a dtb file in the kernel. if this option is set ```KERNEL_IMAGE_DTB``` also needs to be set. if not an attempt to find it will occur.
+`KERNEL_IMAGE_WITH_DTB` determines whether or not to include a dtb file in the kernel. if this option is set `KERNEL_IMAGE_DTB` also needs to be set. if not an attempt to find it will occur.
 
-```KERNEL_IMAGE_DTB``` is the path to the dtb file which can be found in arch/YOURARCH/boot/dts/SOC/
+`KERNEL_IMAGE_DTB` is the path to the dtb file which can be found in arch/YOURARCH/boot/dts/SOC/
 
-```KERNEL_IMAGE_WITH_DTB_OVERLAY``` determines whether or not to build a dtbo file. if this option is set ```KERNEL_IMAGE_DTB_OVERLAY``` also needs to be set. if not an attempt to find it will occur.
+`KERNEL_IMAGE_WITH_DTB_OVERLAY` determines whether or not to build a dtbo file. if this option is set `KERNEL_IMAGE_DTB_OVERLAY` also needs to be set. if not an attempt to find it will occur.
 
-```KERNEL_IMAGE_DTB_OVERLAY``` is the path to the dtbo file which can be found in arch/YOURARCH/boot/dts/SOC/
+`KERNEL_IMAGE_DTB_OVERLAY` is the path to the dtbo file which can be found in arch/YOURARCH/boot/dts/SOC/
 
 All these values can be viewed by extracting a boot image with unpackbootimg
 
-```KERNEL_BOOTIMAGE_CMDLINE``` corresponds to "command line args" or "BOARD_KERNEL_CMDLINE" ```console=tty0``` and ```droidian.lvm.prefer``` should be appended to the cmdline.
+`KERNEL_BOOTIMAGE_CMDLINE` corresponds to "command line args" or "BOARD_KERNEL_CMDLINE" `console=tty0` and `droidian.lvm.prefer` should be appended to the cmdline. Make sure to remove any `systempart` entry from cmdline.
 
-```KERNEL_BOOTIMAGE_PAGE_SIZE``` corresponds to "page size" or "BOARD_PAGE_SIZE"
+`KERNEL_BOOTIMAGE_PAGE_SIZE` corresponds to "page size" or "BOARD_PAGE_SIZE"
 
-```KERNEL_BOOTIMAGE_BASE_OFFSET``` corresponds to "base" or "BOARD_KERNEL_BASE"
+`KERNEL_BOOTIMAGE_BASE_OFFSET` corresponds to "base" or "BOARD_KERNEL_BASE"
 
-```KERNEL_BOOTIMAGE_KERNEL_OFFSET``` corresponds to "kernel load address" or "BOARD_KERNEL_OFFSET"
+`KERNEL_BOOTIMAGE_KERNEL_OFFSET` corresponds to "kernel load address" or "BOARD_KERNEL_OFFSET"
 
-```KERNEL_BOOTIMAGE_INITRAMFS_OFFSET```corresponds to "ramdisk load address" or "BOARD_RAMDISK_OFFSET"
+`KERNEL_BOOTIMAGE_INITRAMFS_OFFSET` corresponds to "ramdisk load address" or "BOARD_RAMDISK_OFFSET"
 
-```KERNEL_BOOTIMAGE_SECONDIMAGE_OFFSET``` corresponds to "second bootloader load address" or
-"BOARD_SECOND_OFFSET"
+`KERNEL_BOOTIMAGE_SECONDIMAGE_OFFSET` corresponds to "second bootloader load address" or "BOARD_SECOND_OFFSET"
 
-```KERNEL_BOOTIMAGE_TAGS_OFFSET``` corresponds to "kernel tags load address" or "BOARD_TAGS_OFFSET"
+`KERNEL_BOOTIMAGE_TAGS_OFFSET` corresponds to "kernel tags load address" or "BOARD_TAGS_OFFSET"
 
-```KERNEL_BOOTIMAGE_DTB_OFFSET``` corresponds to "dtb address" or "BOARD_DTB_OFFSET"
+`KERNEL_BOOTIMAGE_DTB_OFFSET` corresponds to "dtb address" or "BOARD_DTB_OFFSET"
 
 although this option is only required for kernel header version 2. it can be commented otherwise.
 
-```KERNEL_BOOTIMAGE_VERSION``` correlates to the kernel header version. Devices launched with Android 8 and lower are 0, Android 9 is 1, Android 10 is 2 and Android 11 is 2 and GKI devices are 3.
+`KERNEL_BOOTIMAGE_VERSION` correlates to the kernel header version. Devices launched with Android 8 and lower are 0, Android 9 is 1, Android 10 is 2 and Android 11 is 2 and GKI devices are 3.
 
-For Samsung devices ```DEVICE_VBMETA_IS_SAMSUNG``` must be set to 1
+For Samsung devices `DEVICE_VBMETA_IS_SAMSUNG` must be set to 1
 
-```BUILD_CC``` for most devices launched with Android 9 and above is clang but if your kernel fails to build with clang you might try changing the value to aarch64-linux-android-gcc-4.9 to build with gcc.
+`BUILD_CC` for most devices launched with Android 9 and above is clang but if your kernel fails to build with clang you might try changing the value to aarch64-linux-android-gcc-4.9 to build with gcc.
 
-```DEB_BUILD_FOR``` and ```KERNEL_ARCH``` should be changed according to device architecture.
+`DEB_BUILD_FOR` and `KERNEL_ARCH` should be changed according to device architecture.
 
 ### Enabling automatic boot partition flashing
 
@@ -171,25 +166,19 @@ put in place - but the user should still flash it to their boot partition.
 If you wish to enable automatic flashing (via [flash-bootimage](https://github.com/droidian/flash-bootimage)),
 you can do so by setting `FLASH_ENABLED` to 1 (which is the default).
 
-If your device doesn't support A/B updates, be sure to set `FLASH_IS_LEGACY_DEVICE`
-to 1.
+If your device doesn't support A/B updates, be sure to set `FLASH_IS_LEGACY_DEVICE` to 1.
 
-Note that you need to specify some device info so that `flash-bootimage`
-can cross-check when running on-device:
+Note that you need to specify some device info so that `flash-bootimage` can cross-check when running on-device:
 
 * `FLASH_INFO_MANUFACTURER`: the value of the `ro.product.vendor.manufacturer`
 Android property. On a running Droidian system, you can obtain it with
 
-```
-sudo android_getprop ro.product.vendor.manufacturer
-```
+`sudo android_getprop ro.product.vendor.manufacturer`
 
 * `FLASH_INFO_MODEL`: the value of the `ro.product.vendor.model`
 Android property. On a running Droidian system, you can obtain it with
 
-```
-sudo android_getprop ro.product.vendor.model
-```
+`sudo android_getprop ro.product.vendor.model`
 
 * `FLASH_INFO_CPU`: a relevant bit of info from `/proc/cpuinfo`.
 
@@ -197,8 +186,7 @@ If `FLASH_INFO_MANUFACTURER` or `FLASH_INFO_MODEL` are not defined (they both
 are required for checking against the Android properties), `flash-bootimage`
 will check for `FLASH_INFO_CPU`.
 
-If no device-specific information has been specified, the kernel upgrade
-will fail.
+If no device-specific information has been specified, the kernel upgrade will fail.
 
 An example for the F(x)tec Pro1:
 
@@ -211,7 +199,9 @@ FLASH_INFO_CPU = Qualcomm Technologies, Inc MSM8998
 
 Kernel adaptation
 -----------------
+
 As a bare minimum these options need to be enabled in your defconfig
+
 ```
 CONFIG_DEVTMPFS
 CONFIG_VT
@@ -221,7 +211,7 @@ CONFIG_DEVPTS_MULTIPLE_INSTANCES
 CONFIG_USB_CONFIGFS_RNDIS
 ```
 
-Usually CONFIG_NAMESPACES enables all the namespace options but if it did not, all these options should be added
+Usually `CONFIG_NAMESPACES` enables all the namespace options but if it did not, all these options should be added
 
 ```
 CONFIG_SYSVIPC
@@ -230,16 +220,18 @@ CONFIG_IPC_NS
 CONFIG_UTS_NS
 ```
 
-Later on for other components, other options can be enabled after the initial boot is done successfully.
+Later on for other components, various options should be enabled after the initial boot is done successfully.
 
 As an example for Bluetooth these options might be required
+
 ```
 CONFIG_BT
 CONFIG_BT_HCIVHCI
 ```
+
 You can use menuconfig to make sure all the options are enabled with all their dependencies.
 
-If LXC fails to start you can use ```lxc-checkconfig``` after device first booted to check for other options that might be needed.
+If LXC fails to start you can use `lxc-checkconfig` after device first booted to check for other options that might be needed.
 
 Compiling
 ---------

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -108,7 +108,7 @@ by unpacking an already built `boot.img` using unpackbootimg all the offsets can
 Kernel info options
 -------------------
 
-`KERNEL_BASE_VERSION` is the kernel version which can be viewed in Makefile at the root of your kernel source.
+* `KERNEL_BASE_VERSION` is the kernel version which can be viewed in Makefile at the root of your kernel source.
 
 As an example
 
@@ -120,43 +120,43 @@ SUBLEVEL = 221
 
 will be 4.14.221
 
-`KERNEL_DEFCONFIG` is the defconfig filename found at arch/YOURARCH/configs
+* `KERNEL_DEFCONFIG` is the defconfig filename found at arch/YOURARCH/configs
 
-`KERNEL_IMAGE_WITH_DTB` determines whether or not to include a dtb file in the kernel. if this option is set `KERNEL_IMAGE_DTB` also needs to be set. if not an attempt to find it will occur.
+* `KERNEL_IMAGE_WITH_DTB` determines whether or not to include a dtb file in the kernel. if this option is set `KERNEL_IMAGE_DTB` also needs to be set. if not an attempt to find it will occur.
 
-`KERNEL_IMAGE_DTB` is the path to the dtb file which can be found in arch/YOURARCH/boot/dts/SOC/
+* `KERNEL_IMAGE_DTB` is the path to the dtb file which can be found in arch/YOURARCH/boot/dts/SOC/
 
-`KERNEL_IMAGE_WITH_DTB_OVERLAY` determines whether or not to build a dtbo file. if this option is set `KERNEL_IMAGE_DTB_OVERLAY` also needs to be set. if not an attempt to find it will occur.
+* `KERNEL_IMAGE_WITH_DTB_OVERLAY` determines whether or not to build a dtbo file. if this option is set `KERNEL_IMAGE_DTB_OVERLAY` also needs to be set. if not an attempt to find it will occur.
 
-`KERNEL_IMAGE_DTB_OVERLAY` is the path to the dtbo file which can be found in arch/YOURARCH/boot/dts/SOC/
+* `KERNEL_IMAGE_DTB_OVERLAY` is the path to the dtbo file which can be found in arch/YOURARCH/boot/dts/SOC/
 
 All these values can be viewed by extracting a boot image with unpackbootimg
 
-`KERNEL_BOOTIMAGE_CMDLINE` corresponds to "command line args" or "BOARD_KERNEL_CMDLINE" `console=tty0` and `droidian.lvm.prefer` should be appended to the cmdline. Make sure to remove any `systempart` entry from cmdline.
+* `KERNEL_BOOTIMAGE_CMDLINE` corresponds to "command line args" or "BOARD_KERNEL_CMDLINE" `console=tty0` and `droidian.lvm.prefer` should be appended to the cmdline. Make sure to remove any `systempart` entry from cmdline.
 
-`KERNEL_BOOTIMAGE_PAGE_SIZE` corresponds to "page size" or "BOARD_PAGE_SIZE"
+* `KERNEL_BOOTIMAGE_PAGE_SIZE` corresponds to "page size" or "BOARD_PAGE_SIZE"
 
-`KERNEL_BOOTIMAGE_BASE_OFFSET` corresponds to "base" or "BOARD_KERNEL_BASE"
+* `KERNEL_BOOTIMAGE_BASE_OFFSET` corresponds to "base" or "BOARD_KERNEL_BASE"
 
-`KERNEL_BOOTIMAGE_KERNEL_OFFSET` corresponds to "kernel load address" or "BOARD_KERNEL_OFFSET"
+* `KERNEL_BOOTIMAGE_KERNEL_OFFSET` corresponds to "kernel load address" or "BOARD_KERNEL_OFFSET"
 
-`KERNEL_BOOTIMAGE_INITRAMFS_OFFSET` corresponds to "ramdisk load address" or "BOARD_RAMDISK_OFFSET"
+* `KERNEL_BOOTIMAGE_INITRAMFS_OFFSET` corresponds to "ramdisk load address" or "BOARD_RAMDISK_OFFSET"
 
-`KERNEL_BOOTIMAGE_SECONDIMAGE_OFFSET` corresponds to "second bootloader load address" or "BOARD_SECOND_OFFSET"
+* `KERNEL_BOOTIMAGE_SECONDIMAGE_OFFSET` corresponds to "second bootloader load address" or "BOARD_SECOND_OFFSET"
 
-`KERNEL_BOOTIMAGE_TAGS_OFFSET` corresponds to "kernel tags load address" or "BOARD_TAGS_OFFSET"
+* `KERNEL_BOOTIMAGE_TAGS_OFFSET` corresponds to "kernel tags load address" or "BOARD_TAGS_OFFSET"
 
-`KERNEL_BOOTIMAGE_DTB_OFFSET` corresponds to "dtb address" or "BOARD_DTB_OFFSET"
+* `KERNEL_BOOTIMAGE_DTB_OFFSET` corresponds to "dtb address" or "BOARD_DTB_OFFSET"
 
-although this option is only required for kernel header version 2. it can be commented otherwise.
+Although this option is only required for kernel header version 2. it can be commented otherwise.
 
-`KERNEL_BOOTIMAGE_VERSION` correlates to the kernel header version. Devices launched with Android 8 and lower are 0, Android 9 is 1, Android 10 is 2 and Android 11 is 2 and GKI devices are 3.
+* `KERNEL_BOOTIMAGE_VERSION` correlates to the kernel header version. Devices launched with Android 8 and lower are 0, Android 9 is 1, Android 10 is 2 and Android 11 is 2 and GKI devices are 3.
 
-For Samsung devices `DEVICE_VBMETA_IS_SAMSUNG` must be set to 1
+* For Samsung devices `DEVICE_VBMETA_IS_SAMSUNG` must be set to 1.
 
-`BUILD_CC` for most devices launched with Android 9 and above is clang but if your kernel fails to build with clang you might try changing the value to aarch64-linux-android-gcc-4.9 to build with gcc.
+* `BUILD_CC` for most devices launched with Android 9 and above is clang but if your kernel fails to build with clang you might try changing the value to aarch64-linux-android-gcc-4.9 to build with gcc.
 
-`DEB_BUILD_FOR` and `KERNEL_ARCH` should be changed according to device architecture.
+* `DEB_BUILD_FOR` and `KERNEL_ARCH` should be changed according to device architecture.
 
 ### Enabling automatic boot partition flashing
 

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -109,11 +109,11 @@ Kernel info options
 
 unpackbootimg syntax goes as follows
 
-`unpackbootimg --boot_img boot.img`
+`(docker)# unpackbootimg --boot_img boot.img`
 
 or for the AOSP version of unpackbootimg
 
-`unpackbootimg -i boot.img`
+`(docker)# unpackbootimg -i boot.img`
 
 ### kernel-info.mk entries
 

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -52,7 +52,7 @@ Prerequisites
 * A Halium-compliant kernel defconfig
 * Docker
 
-If you do not have a Halium-compliant kernel yet you can try modifying the defconfig as suggested in [Kernel adaptation](#kernel-adaptation) later in the guide.
+If you do not have a Halium-compliant kernel yet you should modify your kernel's configuration as suggested in [Kernel adaptation](#kernel-adaptation) later in the guide.
 
 Package bring-up
 ----------------
@@ -62,8 +62,7 @@ you should create a new branch to house the Debian packaging.
 
 We're also assuming that you want the resulting packages in `~/droidian/packages`.
 
-Droidian tooling expects the branch to be named after the Debian
-codename, such as `bookworm`
+Droidian tooling expects the kernel source to have a working git directory structure (be a kernel cloned from a git repository) and the branch to be named after the Debian codename, such as `bookworm`.
 
 	(host)$ KERNEL_DIR="$HOME/droidian/kernel/vendor/device"
 	(host)$ PACKAGES_DIR="$HOME/droidian/packages"
@@ -107,6 +106,16 @@ by unpacking an already built `boot.img` using unpackbootimg all the offsets can
 
 Kernel info options
 -------------------
+
+unpackbootimg syntax goes as follows
+
+`unpackbootimg --boot_img boot.img`
+
+or for the AOSP version of unpackbootimg
+
+`unpackbootimg -i boot.img`
+
+### kernel-info.mk entries
 
 * `KERNEL_BASE_VERSION` is the kernel version which can be viewed in Makefile at the root of your kernel source.
 
@@ -154,7 +163,7 @@ Although this option is only required for kernel header version 2. it can be com
 
 * For Samsung devices `DEVICE_VBMETA_IS_SAMSUNG` must be set to 1.
 
-* `BUILD_CC` for most devices launched with Android 9 and above is clang but if your kernel fails to build with clang you might try changing the value to aarch64-linux-android-gcc-4.9 to build with gcc.
+* `BUILD_CC` for most devices launched with Android 9 and above is clang but if your kernel fails to build with `clang` you might try changing the value to `aarch64-linux-android-gcc-4.9` to build with gcc.
 
 * `DEB_BUILD_FOR` and `KERNEL_ARCH` should be changed according to device architecture.
 
@@ -231,6 +240,10 @@ CONFIG_BT_HCIVHCI
 
 You can use menuconfig to make sure all the options are enabled with all their dependencies.
 
+`mkdir -p out/KERNEL_OBJ && make ARCH=arm64 O=out/KERNEL_OBJ/ your_defconfig && make ARCH=arm64 O=out/KERNEL_OBJ/ menuconfig`
+
+After modifying your defconfig, copy `out/KERNEL_OBJ/.config` to `arch/YOURARCH/configs/your_defconfig`.
+
 If LXC fails to start you can use `lxc-checkconfig` after device first booted to check for other options that might be needed.
 
 Compiling
@@ -255,8 +268,7 @@ If everything goes well, you'll find the resulting packages in `$PACKAGES_DIR`.
 Obtaining the boot image
 ------------------------
 
-The boot image is shipped into the `linux-bootimage-VERSION-VENDOR-DEVICE`
-package.
+The boot image is shipped into the `linux-bootimage-VERSION-VENDOR-DEVICE` package.
 
 You can pick up the boot.img by extracting the package with `dpkg-deb` or
 by picking up directly from the compiled artifacts (`out/KERNEL_OBJ/boot.img`).
@@ -266,7 +278,7 @@ The kernel image already embeds the generic Halium initramfs.
 Committing changes
 ------------------
 
-When you're happy with the kernel, be sure to commit the following files in git:
+When you're happy with the kernel, be sure to commit your changes as well as the debian packaging to a git repository:
 
 * debian/source/
 * debian/control

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -109,11 +109,11 @@ Kernel info options
 
 unpackbootimg syntax goes as follows
 
-`(docker)# unpackbootimg --boot_img boot.img`
+	(docker)# unpackbootimg --boot_img boot.img
 
 or for the AOSP version of unpackbootimg
 
-`(docker)# unpackbootimg -i boot.img`
+	(docker)# unpackbootimg -i boot.img
 
 ### kernel-info.mk entries
 
@@ -182,12 +182,12 @@ Note that you need to specify some device info so that `flash-bootimage` can cro
 * `FLASH_INFO_MANUFACTURER`: the value of the `ro.product.vendor.manufacturer`
 Android property. On a running Droidian system, you can obtain it with
 
-`sudo android_getprop ro.product.vendor.manufacturer`
+	(device)$ sudo android_getprop ro.product.vendor.manufacturer
 
 * `FLASH_INFO_MODEL`: the value of the `ro.product.vendor.model`
 Android property. On a running Droidian system, you can obtain it with
 
-`sudo android_getprop ro.product.vendor.model`
+	(device)$ sudo android_getprop ro.product.vendor.model
 
 * `FLASH_INFO_CPU`: a relevant bit of info from `/proc/cpuinfo`.
 
@@ -240,7 +240,7 @@ CONFIG_BT_HCIVHCI
 
 You can use menuconfig to make sure all the options are enabled with all their dependencies.
 
-`mkdir -p out/KERNEL_OBJ && make ARCH=arm64 O=out/KERNEL_OBJ/ your_defconfig && make ARCH=arm64 O=out/KERNEL_OBJ/ menuconfig`
+	(docker)# mkdir -p out/KERNEL_OBJ && make ARCH=arm64 O=out/KERNEL_OBJ/ your_defconfig && make ARCH=arm64 O=out/KERNEL_OBJ/ menuconfig
 
 After modifying your defconfig, copy `out/KERNEL_OBJ/.config` to `arch/YOURARCH/configs/your_defconfig`.
 
@@ -273,7 +273,9 @@ The boot image is shipped into the `linux-bootimage-VERSION-VENDOR-DEVICE` packa
 You can pick up the boot.img by extracting the package with `dpkg-deb` or
 by picking up directly from the compiled artifacts (`out/KERNEL_OBJ/boot.img`).
 
-The kernel image already embeds the generic Halium initramfs.
+The kernel image already embeds the Droidian initramfs.
+
+Make sure to save all your `linux-*.deb` packages as you'll need those further in the guide.
 
 Committing changes
 ------------------

--- a/kernel-compilation.md
+++ b/kernel-compilation.md
@@ -48,7 +48,7 @@ Debian toolchain.
 
 Using this method you can also compile and package mainline kernels.
 
-An example kernel packaged using this guide is the [Android Kernel for the F(x)tec Pro1](https://github.com/droidian/linux-android-fxtec-pro1/tree/feature/bookworm/initial-packaging/debian).
+An example kernel packaged using this guide is the [Android Kernel for the F(x)tec Pro1](https://github.com/droidian-devices/linux-android-fxtec-pro1/tree/bookworm/debian).
 
 Prerequisites
 -------------

--- a/rootfs-creation.md
+++ b/rootfs-creation.md
@@ -1,5 +1,6 @@
 Rootfs creation
 ===============
+To make the installation easier and more consistent we build device specific rootfs images.
 
 Table of contents
 -----------------
@@ -46,29 +47,29 @@ As you will be building for a device with another architecture, you must initial
 
 Go to the newly created adaptation directory
 
-	(host)$ cd ~/droidian/vendor/codename/packages/adaptation-vendor-codename/
+	(host)$ cd ~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/
 
 Now put all your device specific files under `sparse/` with a linux directory structure
 
-Make sure to put your repository's URL in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list` with this format
+Make sure to put your repository's URL in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list` with this format
 
 `deb [signed-by=/usr/share/keyrings/codename.gpg] https://YOURREPO.TLD bookworm main`
 
-Then copy your gpg file to `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/share/keyrings/codename.gpg`. Make sure to replace codename.
+Then copy your gpg file to `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/share/keyrings/codename.gpg`. Make sure to replace codename.
 
 After copying all your files build the deb package
 
-	(host)$ droidian-build-package
+	(host)$ ~/droidian-build-tools/droidian-build-package
 
-Make sure to copy all the files from `~/droidian/vendor/codename/droidian/apt` to the repository you specified in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list`
+Make sure to copy all the files from `~/droidian-build-tools/droidian/vendor/codename/droidian/apt` to the repository you specified in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list`
 
 Also make sure to commit your repository/changes to a git repository.
 
 Building the rootfs
 -------------------
 
-Before building the rootfs make sure to add your `linux-*.deb` packages you have build during the kernel compilation process to `~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/community_devices.yml` as a package entry.
-As an alternative solution you can try adding those packages as a dependency to your adaptation package in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/debian/control`.
+Before building the rootfs make sure to add your `linux-*.deb` packages you have build during the kernel compilation process to `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/community_devices.yml` as a package entry.
+As an alternative solution you can try adding those packages as a dependency to your adaptation package in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/debian/control`.
 
 First pull the rootfs-builder docker image
 
@@ -76,9 +77,9 @@ First pull the rootfs-builder docker image
 
 Now run debos in the docker container rootfs-builder to build the rootfs. Make sure to replace the placeholder values
 
-	(host)$ cd ~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/ && mkdir images && docker run --privileged -v $PWD/images:/buildd/out -v /dev:/host-dev -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/buildd/sources --security-opt seccomp:unconfined quay.io/droidian/rootfs-builder:bookworm-amd64 /bin/sh -c 'cd /buildd/sources; DROIDIAN_VERSION="nightly" ./generate_device_recipe.py vendor_codename ARCH phosh phone APIVER && debos --disable-fakemachine generated/droidian.yaml'
+	(host)$ cd ~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/ && mkdir images && docker run --privileged -v $PWD/images:/buildd/out -v /dev:/host-dev -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/buildd/sources --security-opt seccomp:unconfined quay.io/droidian/rootfs-builder:bookworm-amd64 /bin/sh -c 'cd /buildd/sources; DROIDIAN_VERSION="nightly" ./generate_device_recipe.py vendor_codename ARCH phosh phone APIVER && debos --disable-fakemachine generated/droidian.yaml'
 
-If everything builds fine you should have your LVM fastboot flashable rootfs image in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/images/`.
+If everything builds fine you should have your LVM fastboot flashable rootfs image in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/images/`.
 
 Automating nightly images
 -------------------------

--- a/rootfs-creation.md
+++ b/rootfs-creation.md
@@ -78,6 +78,7 @@ Building the rootfs
 -------------------
 
 Before building the rootfs make sure to add your `linux-*.deb` packages you have build during the kernel compilation process to `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/community_devices.yml` as a package entry.
+
 As an alternative solution you can try adding those packages as a dependency to your adaptation package in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/debian/control`.
 
 First pull the rootfs-builder docker image
@@ -86,13 +87,15 @@ First pull the rootfs-builder docker image
 
 Now run debos in the docker container rootfs-builder to build the rootfs. Make sure to replace the placeholder values
 
-	(host)$ cd ~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/ && mkdir images && docker run --privileged -v $PWD/images:/buildd/out -v /dev:/host-dev -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/buildd/sources --security-opt seccomp:unconfined quay.io/droidian/rootfs-builder:bookworm-amd64 /bin/sh -c 'cd /buildd/sources; DROIDIAN_VERSION="nightly" ./generate_device_recipe.py vendor_codename ARCH phosh phone APIVER && debos --disable-fakemachine generated/droidian.yaml'
+	(host)$ cd ~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/
+	(host)$ mkdir images
+	(host)$ docker run --privileged -v $PWD/images:/buildd/out -v /dev:/host-dev -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/buildd/sources --security-opt seccomp:unconfined quay.io/droidian/rootfs-builder:bookworm-amd64 /bin/sh -c 'cd /buildd/sources; DROIDIAN_VERSION="nightly" ./generate_device_recipe.py vendor_codename ARCH phosh phone APIVER && debos --disable-fakemachine generated/droidian.yaml'
 
 If everything builds fine you should have your LVM fastboot flashable rootfs image in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/images/`.
 
 Automating nightly images
 -------------------------
 
-You can automate your builds with GitHub actions to generate new images every day for your device with your changes. Take [this actions yml file](https://github.com/droidian-onclite/droidian-images/blob/bookworm/.github/workflows/release.yml) as an example
+You can automate your builds with GitHub actions to generate new images every day for your device with your changes. Take [this actions yml file](https://github.com/droidian-onclite/droidian-images/blob/bookworm/.github/workflows/release.yml) as an example.
 
 You can replicate nightly builds by replacing the values in `community_devices.yml` and files in `apt/`.

--- a/rootfs-creation.md
+++ b/rootfs-creation.md
@@ -63,6 +63,15 @@ After copying all your files build the deb package
 
 Make sure to copy all the files from `~/droidian-build-tools/droidian/vendor/codename/droidian/apt` to the repository you specified in `~/droidian-build-tools/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list`
 
+Now at this point you can use `package-sideload-create` on your droidian device to create a recovery flashable package from those two deb packages.
+
+After copying the deb files to your personal repository, add that repository to your device by adding the sources list file to your device then do
+
+	(device)# apt update
+	(device)# package-sideload-create adaptation-droidian-codename.zip adaptation-vendor-codename adaptation-vendor-codename-configs
+
+At the end you should get a zip file which is flashable from recovery and has all your changes.
+
 Also make sure to commit your repository/changes to a git repository.
 
 Building the rootfs

--- a/rootfs-creation.md
+++ b/rootfs-creation.md
@@ -1,0 +1,88 @@
+Rootfs creation
+===============
+
+Table of contents
+-----------------
+
+* [Summary](#summary)
+* [Prerequisites](#prerequisites)
+* [Package creation](#package-creation)
+* [Building the rootfs](#building-the-rootfs)
+* [Automating nightly images](#automating-nightly-images)
+
+Summary
+-------
+
+After debugging you should start building a rootfs specific to your device to make installations more consistent and user friendly.
+
+This process involves creating an adaptation package and an apt repository
+
+Adaptation package is a debian package that holds all the device specific configurations and custom binaries and scripts needed for the device to function correctly.
+
+To be able to do OTA updates, you have to set up an apt repository either on some platform like GitHub or a server.
+
+Creation of the apt repository is out of the scope of this tutorial.
+
+Prerequisites
+-------------
+
+* Device specific files
+* Docker
+
+Package creation
+----------------
+
+First clone into the droidian build tools repository
+
+	(host)$ git clone https://github.com/droidian-releng/droidian-build-tools/ && cd droidian-build-tools
+
+Now create a template for your device. of course replace vendor, codename, ARCH and APIVER
+
+	(host)$ ./droidian-new-device -v vendor -n codename -c ARCH -a APIVER -r phone -d droidian
+
+As you will be building for a device with another architecture, you must initialize qemu-user-static to enable emulation for docker
+
+	(host)$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+Go to the newly created adaptation directory
+
+	(host)$ cd ~/droidian/vendor/codename/packages/adaptation-vendor-codename/
+
+Now put all your device specific files under `sparse/` with a linux directory structure
+
+Make sure to put your repository's URL in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list` with this format
+
+`deb [signed-by=/usr/share/keyrings/codename.gpg] https://YOURREPO.TLD bookworm main`
+
+Then copy your gpg file to `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/share/keyrings/codename.gpg`. Make sure to replace codename.
+
+After copying all your files build the deb package
+
+	(host)$ droidian-build-package
+
+Make sure to copy all the files from `~/droidian/vendor/codename/droidian/apt` to the repository you specified in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/sparse/usr/lib/adaptation-vendor-model/sources.list.d/community-vendor-device.list`
+
+Also make sure to commit your repository/changes to a git repository.
+
+Building the rootfs
+-------------------
+
+Before building the rootfs make sure to add your `linux-*.deb` packages you have build during the kernel compilation process to `~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/community_devices.yml` as a package entry.
+As an alternative solution you can try adding those packages as a dependency to your adaptation package in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/debian/control`.
+
+First pull the rootfs-builder docker image
+
+	(host)$ docker pull quay.io/droidian/rootfs-builder:bookworm-amd64
+
+Now run debos in the docker container rootfs-builder to build the rootfs. Make sure to replace the placeholder values
+
+	(host)$ cd ~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/ && mkdir images && docker run --privileged -v $PWD/images:/buildd/out -v /dev:/host-dev -v /sys/fs/cgroup:/sys/fs/cgroup -v $PWD:/buildd/sources --security-opt seccomp:unconfined quay.io/droidian/rootfs-builder:bookworm-amd64 /bin/sh -c 'cd /buildd/sources; DROIDIAN_VERSION="nightly" ./generate_device_recipe.py vendor_codename ARCH phosh phone APIVER && debos --disable-fakemachine generated/droidian.yaml'
+
+If everything builds fine you should have your LVM fastboot flashable rootfs image in `~/droidian/vendor/codename/packages/adaptation-vendor-codename/droidian/images/`.
+
+Automating nightly images
+-------------------------
+
+You can automate your builds with GitHub actions to generate new images every day for your device with your changes. Take [this actions yml file](https://github.com/droidian-onclite/droidian-images/blob/bookworm/.github/workflows/release.yml) as an example
+
+You can replicate nightly builds by replacing the values in `community_devices.yml` and files in `apt/`.


### PR DESCRIPTION
change the URL of fxtec pro 1 as branch feature/bookworm/initial-packaging doesn't exist
also add information about entries in kernel-info.mk 
as well as a list of needed options in defconfig for a halium system to boot.
full system image guide has also been added.

added a repository for the android/halium build system to use droidian's ramdisk (currently under the droidian-hammerhead organization should probably be moved to the main droidian organization)